### PR TITLE
Twitter APIのトークンを環境変数へ

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -2,8 +2,7 @@
 require 'nokogiri'
 require 'open-uri'
 require 'kconv'
-require '/projects/kyuko/pass.rb'
-# require "./pass.rb"
+require_relative 'pass.rb'
 
 class NoLectures
   def initialize(today, place)

--- a/notification.rb
+++ b/notification.rb
@@ -1,0 +1,40 @@
+require 'twitter'
+
+module Notification
+  module Twitter
+    module Config
+      def self.token(campus)
+        case campus
+        when :imadegawa
+          prefix = 'IMADEGAWA'
+        when :kyotanabe
+          prefix = 'KYOTANABE'
+        else
+          raise 'invalid campus'
+        end
+
+        token = {
+          consumer_key: ENV["TWITTER_#{prefix}_CONSUMER_KEY"],
+          consumer_secret: ENV["TWITTER_#{prefix}_CONSUMER_SECRET"],
+          access_token: ENV["TWITTER_#{prefix}_ACCESS_TOKEN"],
+          access_token_secret: ENV["TWITTER_#{prefix}_ACCESS_TOKEN_SECRET"]
+        }
+
+        raise "TWITTER_#{prefix}_* has nil" if token.value? nil
+
+        token
+      end
+    end
+
+    module Tweet
+      @queue = :tweet
+
+      def self.perform(campus, message)
+        token = Notification::Twitter::Config.token(campus)
+        twitter = Twitter::REST::Client.new(token)
+        twitter.update message
+        nil
+      end
+    end
+  end
+end

--- a/test.rb
+++ b/test.rb
@@ -1,15 +1,3 @@
-# encoding: utf-8
-require '/projects/kyuko/pass.rb'
-require 'twitter'
-require 'clockwork'
-require 'date'
-require '/projects/kyuko/app.rb'
+require './notification.rb'
 
-client = Twitter::REST::Client.new(
-  consumer_key:        CONSUMER_KEY,
-  consumer_secret:     CONSUMER_SECRET,
-  access_token:        ACCESS_TOKEN,
-  access_token_secret: ACCESS_TOKEN_SECRET
-)
-
-client.update('test')
+puts Notification::Twitter::Config.token :imadegawa

--- a/tweet.rb
+++ b/tweet.rb
@@ -1,31 +1,19 @@
 # encoding: utf-8
-require '/projects/kyuko/pass.rb'
-# require "./pass.rb"
 require 'twitter'
 require 'clockwork'
 require 'date'
-require '/projects/kyuko/app.rb'
-# require "./app.rb"
+require_relative 'app.rb'
+require_relative 'notification.rb'
+require_relative 'pass.rb'
 
 class Tweet
-  def initialize(c_key, c_secret, a_token, a_token_secret, place)
-    @consumer_key = ''
-    @consemer_secret = ''
-    @access_token = ''
-    @access_token_secret = ''
-
-    @client = Twitter::REST::Client.new(
-      consumer_key:        c_key,
-      consumer_secret:     c_secret,
-      access_token:        a_token,
-      access_token_secret: a_token_secret
-    )
-
+  def initialize(place)
     @nolec = NoLectures.new(@youbi, place)
     @date = DateTime.now
     @youbi = @nolec.change_youbi_int(@date.strftime('%a'))
     @nolec.set_today(@youbi)
     @contents = []
+    @place = place
   end
 
   def set_time
@@ -80,7 +68,7 @@ class Tweet
   def update_tweet
     @contents.each do |content|
       puts content
-      @client.update(content)
+      Notification::Twitter::Tweet.perform(@place == 1 ? :imadegawa : :kyotanabe, content)
     end
   end
 end
@@ -91,7 +79,7 @@ every(2.hours, 'work') do
   puts "田辺"
   # 田辺
   # 今日の曜日をset
-  tw_tanabe = Tweet.new(T_CONSUMER_KEY, T_CONSUMER_SECRET, T_ACCESS_TOKEN, T_ACCESS_TOKEN_SECRET, 2)
+  tw_tanabe = Tweet.new(2)
   # 今何時か調べて、21よりあとなら明日の情報
   tw_tanabe.set_tomorrow
   tw_tanabe.create_contents
@@ -100,7 +88,7 @@ every(2.hours, 'work') do
   puts "今出川"
   # 今出川
   # 今日の曜日をset
-  tw_imade = Tweet.new(I_CONSUMER_KEY, I_CONSUMER_SECRET, I_ACCESS_TOKEN, I_ACCESS_TOKEN_SECRET, 1)
+  tw_imade = Tweet.new(1)
   # 今何時か調べて、21よりあとなら明日の情報
   tw_imade.set_tomorrow
   tw_imade.create_contents


### PR DESCRIPTION
- Twitter APIのトークンを環境変数へ
- require_relative
- resqueの布石(最終的にTwitterはNotification::Twitterにまとめます)

複数指定できない問題はprefixをつけることで解決しました．

- 今出川
  - TWITTER_IMADEGAWA_*
- 京田辺
  - TWITTER_KYOTANABE_*

@g-hyoga レビューお願いします