### PR TITLE
Scrape()の簡易ベンチマークを追加

### DIFF
--- a/go/scrape/scrape_test.go
+++ b/go/scrape/scrape_test.go
@@ -251,3 +251,12 @@ func TestScrape(t *testing.T) {
 		t.Fatal("scrapingに失敗しました\n%s", err)
 	}
 }
+
+func BenchmarkScrape(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_, err := Scrape(kyukoDoc)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
```
su> go test -bench .
BenchmarkScrape-8   	   30000	     58454 ns/op
PASS
ok  	github.com/g-hyoga/kyuko/go/scrape	2.343s
```