### PR TITLE
データの保存構造変える

### DIFF
--- a/go/Makefile
+++ b/go/Makefile
@@ -16,17 +16,6 @@ run:
 test:
 	godep go test -v ./...
 
-test/up:
-	sql-migrate up -env="development"
-
-test/down:
-	sql-migrate -env="development"
-
-test/init:
-	#sudo service mysql restart
-	sudo mysql.server restart
-	mysql -u root -h localhost --protocol tcp -e "create database \`$(TESTDB)\`" -p
-
 migrate/init:
 	#sudo service mysql restart
 	sudo mysql.server restart

--- a/go/kyuko.go
+++ b/go/kyuko.go
@@ -77,9 +77,8 @@ func Exec(place int, client *goTwitter.Client) ([]model.KyukoData, error) {
 			return nil, err
 		}
 
-		//DBに存在するデータなら
-		//1日1回っていう条件もいる
-		if id != -1 {
+		//DBに存在するデータかつ今日のデータでないなら
+		if isExist, _ := db.IsExistToday(data); id != -1 && !isExist {
 			canceledClass.ID = id
 			_, err = db.AddCanceled(canceledClass.ID)
 			if err != nil {

--- a/go/kyuko.go
+++ b/go/kyuko.go
@@ -71,6 +71,7 @@ func Exec(place int, client *goTwitter.Client) ([]model.KyukoData, error) {
 			return nil, err
 		}
 
+		//挿入するデータが存在するのか確認
 		id, err := db.ShowCanceledClassID(canceledClass)
 		if err != nil {
 			return nil, err
@@ -92,6 +93,7 @@ func Exec(place int, client *goTwitter.Client) ([]model.KyukoData, error) {
 		}
 	}
 
+	//masterにmergeする時もどせ
 	//tws, err := twitter.CreateContent(kyukoData)
 	_, err = twitter.CreateContent(kyukoData)
 	if err != nil {

--- a/go/kyuko.go
+++ b/go/kyuko.go
@@ -63,6 +63,16 @@ func Exec(place int, client *goTwitter.Client) error {
 		if err != nil {
 			return err
 		}
+
+		canceledClass, err := model.KyukoToCanceled(data)
+		if err != nil {
+			return err
+		}
+		_, err = db.InsertCanceledClass(canceledClass)
+		if err != nil {
+			return err
+		}
+
 	}
 
 	tws, err := twitter.CreateContent(kyukoData)

--- a/go/kyuko.go
+++ b/go/kyuko.go
@@ -68,13 +68,28 @@ func Exec(place int, client *goTwitter.Client) ([]model.KyukoData, error) {
 
 		canceledClass, err := model.KyukoToCanceled(data)
 		if err != nil {
-			return err
-		}
-		_, err = db.InsertCanceledClass(canceledClass)
-		if err != nil {
-			return err
+			return nil, err
 		}
 
+		//API用
+		id, err := db.ShowCanceledClassID(canceledClass)
+		if err != nil {
+			return nil, err
+		}
+
+		//DBに存在しないデータなら
+		if id == -1 {
+			_, err = db.InsertCanceledClass(canceledClass)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		canceledClass.ID = id
+		_, err = db.AddCanceled(canceledClass.ID)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	//tws, err := twitter.CreateContent(kyukoData)

--- a/go/kyuko.go
+++ b/go/kyuko.go
@@ -71,22 +71,22 @@ func Exec(place int, client *goTwitter.Client) ([]model.KyukoData, error) {
 			return nil, err
 		}
 
-		//API用
 		id, err := db.ShowCanceledClassID(canceledClass)
 		if err != nil {
 			return nil, err
 		}
 
-		//DBに存在しないデータなら
-		if id == -1 {
-			_, err = db.InsertCanceledClass(canceledClass)
+		//DBに存在するデータなら
+		//1日1回っていう条件もいる
+		if id != -1 {
+			canceledClass.ID = id
+			_, err = db.AddCanceled(canceledClass.ID)
 			if err != nil {
 				return nil, err
 			}
 		}
 
-		canceledClass.ID = id
-		_, err = db.AddCanceled(canceledClass.ID)
+		_, err = db.InsertCanceledClass(canceledClass)
 		if err != nil {
 			return nil, err
 		}

--- a/go/kyuko.go
+++ b/go/kyuko.go
@@ -92,22 +92,19 @@ func Exec(place int, client *goTwitter.Client) ([]model.KyukoData, error) {
 		}
 	}
 
-	//masterにmergeする時もどせ
-	//tws, err := twitter.CreateContent(kyukoData)
-	_, err = twitter.CreateContent(kyukoData)
+	tws, err := twitter.CreateContent(kyukoData)
+	//_, err = twitter.CreateContent(kyukoData)
 	if err != nil {
 		return nil, err
 	}
 
-	/*
-		for _, tw := range tws {
-			err := twitter.Update(client, tw)
-			if err != nil {
-				return nil, err
-				return nil, err
-			}
+	for _, tw := range tws {
+		err := twitter.Update(client, tw)
+		if err != nil {
+			return nil, err
+			return nil, err
 		}
-	*/
+	}
 
 	return kyukoData, nil
 }

--- a/go/kyuko_test.go
+++ b/go/kyuko_test.go
@@ -20,10 +20,10 @@ var (
 )
 
 func testExec(t *testing.T) {
-
 	tClient := twitter.NewTwitterClient(T_CONSUMER_KEY, T_CONSUMER_SECRET, T_ACCESS_TOKEN, T_ACCESS_TOKEN_SECRET)
-	err := Exec(2, tClient)
+	_, err := Exec(2, tClient)
 	if err != nil {
 		t.Fatalf("%s", err)
 	}
+
 }

--- a/go/model/model.go
+++ b/go/model/model.go
@@ -166,3 +166,12 @@ func getSeason(day string) (string, error) {
 
 	return "", errors.New("Season are not uniquely determined")
 }
+
+func (db *DB) deleteCanceled(id int) (sql.Result, error) {
+	sql := "DELETE FROM canceled_class WHERE id = ?;"
+	result, err := db.db.Exec(sql, id)
+	if err != nil {
+		return result, err
+	}
+	return result, err
+}

--- a/go/model/model.go
+++ b/go/model/model.go
@@ -3,6 +3,8 @@ package model
 import (
 	"database/sql"
 	"errors"
+	"strconv"
+	"strings"
 
 	_ "github.com/go-sql-driver/mysql"
 )
@@ -113,4 +115,45 @@ func (db *DB) DeleteWhereDayAndClassName(day, className string) (sql.Result, err
 		return result, err
 	}
 	return result, err
+}
+
+func KyukoToCanceled(k KyukoData) (CanceledClass, error) {
+	season, err := getSeason(k.Day)
+	if err != nil {
+		return CanceledClass{}, err
+	}
+
+	year, err := getYear(k.Day)
+	if err != nil {
+		return CanceledClass{}, err
+	}
+
+	return CanceledClass{
+		Place:      k.Place,
+		Weekday:    k.Weekday,
+		Period:     k.Period,
+		ClassName:  k.ClassName,
+		Instructor: k.Instructor,
+		Season:     season,
+		Year:       year,
+	}, nil
+}
+
+func getYear(day string) (int, error) {
+	strYear := strings.Split(day, "/")[0]
+	year, _ := strconv.Atoi(strYear)
+	return year, nil
+}
+
+func getSeason(day string) (string, error) {
+	strMonth := strings.Split(day, "/")[1]
+	month, _ := strconv.Atoi(strMonth)
+
+	if month >= 3 && month <= 8 {
+		return "spring", nil
+	} else if (month >= 9 && month <= 12) || (month >= 1 && month <= 2) {
+		return "autumn", nil
+	}
+
+	return "", errors.New("Season are not uniquely determined")
 }

--- a/go/model/model.go
+++ b/go/model/model.go
@@ -30,9 +30,9 @@ func (db *DB) Insert(k KyukoData) (sql.Result, error) {
 }
 
 func (db *DB) InsertCanceledClass(c CanceledClass) (sql.Result, error) {
-	sql := "INSERT INTO `canceled_class` (canceled, place, week, period, year, season, class_name, instructor) VALUES(?, ?, ?, ?, ?, ?, ?, ?) ON DUPLICATE KEY UPDATE `canceled`=?;"
+	sql := "INSERT INTO `canceled_class` (canceled, place, week, period, year, season, class_name, instructor) VALUES(?, ?, ?, ?, ?, ?, ?, ?);"
 
-	result, err := db.db.Exec(sql, c.Canceled, c.Place, c.Weekday, c.Period, c.Year, c.Season, c.ClassName, c.Instructor, c.Canceled)
+	result, err := db.db.Exec(sql, c.Canceled, c.Place, c.Weekday, c.Period, c.Year, c.Season, c.ClassName, c.Instructor)
 	return result, err
 }
 
@@ -111,6 +111,15 @@ func (db *DB) ShowCanceledClassID(c CanceledClass) (int, error) {
 
 func (db *DB) DeleteWhereDayAndClassName(day, className string) (sql.Result, error) {
 	result, err := db.db.Exec("delete from kyuko_data where day = ? and class_name = ?", day, className)
+	if err != nil {
+		return result, err
+	}
+	return result, err
+}
+
+func (db *DB) AddCanceled(id int) (sql.Result, error) {
+	sql := "UPDATE canceled_class SET canceled = canceled+1 WHERE id = ?;"
+	result, err := db.db.Exec(sql, id)
 	if err != nil {
 		return result, err
 	}

--- a/go/model/model.go
+++ b/go/model/model.go
@@ -175,3 +175,43 @@ func (db *DB) deleteCanceled(id int) (sql.Result, error) {
 	}
 	return result, err
 }
+
+func (db *DB) deleteReason(id int) (sql.Result, error) {
+	sql := "DELETE FROM reason WHERE id = ?;"
+	result, err := db.db.Exec(sql, id)
+	if err != nil {
+		return result, err
+	}
+	return result, err
+
+}
+
+func (db *DB) deleteReasonWhere(canceledID int, reason string) (sql.Result, error) {
+	sql := "DELETE FROM reason WHERE canceled_class_id = ? AND reason = ?;"
+	result, err := db.db.Exec(sql, canceledID, reason)
+	if err != nil {
+		return result, err
+	}
+	return result, err
+
+}
+
+func (db *DB) deleteDay(id int) (sql.Result, error) {
+	sql := "DELETE FROM day WHERE id = ?;"
+	result, err := db.db.Exec(sql, id)
+	if err != nil {
+		return result, err
+	}
+	return result, err
+
+}
+
+func (db *DB) deleteDayWhere(canceledID int, reason string) (sql.Result, error) {
+	sql := "DELETE FROM day WHERE canceled_class_id = ? AND day = ?;"
+	result, err := db.db.Exec(sql, canceledID, reason)
+	if err != nil {
+		return result, err
+	}
+	return result, err
+
+}

--- a/go/model/model.go
+++ b/go/model/model.go
@@ -109,6 +109,25 @@ func (db *DB) ShowCanceledClassID(c CanceledClass) (int, error) {
 	return canceledclass[0].ID, nil
 }
 
+func (db *DB) IsExistToday(k KyukoData) (bool, error) {
+	sql := "select * from kyuko_data where class_name=? and day=?"
+	rows, err := db.db.Query(sql, k.ClassName, k.Day)
+	if err != nil {
+		return false, err
+	}
+	defer rows.Close()
+	kyukoData := []KyukoData{}
+	kyukoData, err = ScanAll(rows)
+	if err != nil {
+		return false, err
+	}
+
+	if len(kyukoData) > 0 {
+		return true, nil
+	}
+	return false, nil
+}
+
 func (db *DB) DeleteWhereDayAndClassName(day, className string) (sql.Result, error) {
 	result, err := db.db.Exec("delete from kyuko_data where day = ? and class_name = ?", day, className)
 	if err != nil {

--- a/go/model/model_test.go
+++ b/go/model/model_test.go
@@ -9,6 +9,8 @@ type TestData struct {
 	Delete              KyukoData
 	ShowID              CanceledClass
 	Add                 CanceledClass
+	Reason              Reason
+	Day                 Day
 }
 
 var db DB
@@ -23,7 +25,8 @@ func init() {
 	testData.ShowID = CanceledClass{Canceled: 10, Place: 1, Weekday: 1, Period: 1, Year: 2016, ClassName: "ShowIDTest", Season: "spring", Instructor: "hoge man"}
 	testData.Delete = KyukoData{Place: 1, Weekday: 1, Period: 1, Day: "2016/09/26", ClassName: "Delete Test", Instructor: "tsetMan", Reason: "darui"}
 	testData.Add = CanceledClass{Canceled: 10, Place: 1, Weekday: 1, Period: 1, Year: 2016, ClassName: "ADDTest", Season: "spring", Instructor: "hoge man"}
-
+	testData.Reason = Reason{CanceledClassID: 1, Reason: "darui"}
+	testData.Day = Day{CanceledClassID: 1, Date: "2016/09/26"}
 }
 
 func deleteTestData() {
@@ -37,6 +40,9 @@ func deleteTestData() {
 	db.deleteCanceled(id)
 	id, _ = db.ShowCanceledClassID(testData.Add)
 	db.deleteCanceled(id)
+
+	db.deleteReasonWhere(testData.Reason.CanceledClassID, testData.Reason.Reason)
+	db.deleteDayWhere(testData.Day.CanceledClassID, testData.Day.Date)
 }
 
 func TestConnectDB(t *testing.T) {
@@ -71,9 +77,7 @@ func TestReason(t *testing.T) {
 	defer deleteTestData()
 	var err error
 
-	testData := Reason{CanceledClassID: 1, Reason: "darui"}
-
-	_, err = db.InsertReason(testData)
+	_, err = db.InsertReason(testData.Reason)
 	if err != nil {
 		t.Fatalf("reason の insert に失敗\n%s", err)
 	}
@@ -83,9 +87,7 @@ func TestDay(t *testing.T) {
 	defer deleteTestData()
 	var err error
 
-	testData := Day{CanceledClassID: 1, Date: "2016/09/26"}
-
-	_, err = db.InsertDay(testData)
+	_, err = db.InsertDay(testData.Day)
 	if err != nil {
 		t.Fatalf("day の insert に失敗\n%s", err)
 	}

--- a/go/model/model_test.go
+++ b/go/model/model_test.go
@@ -113,6 +113,26 @@ func TestDelete(t *testing.T) {
 	}
 }
 
+func TestAddCanceled(t *testing.T) {
+	var err error
+	testData := CanceledClass{Canceled: 10, Place: 1, Weekday: 1, Period: 1, Year: 2016, ClassName: "ADDTest", Season: "spring", Instructor: "hoge man"}
+
+	_, err = db.InsertCanceledClass(testData)
+	if err != nil {
+		t.Fatalf("Error AddCanceled Test: failed InsertCanceledClass func\n%s", err)
+	}
+
+	id, err := db.ShowCanceledClassID(testData)
+	if err != nil {
+		t.Fatalf("Error AddCanceled Test: failed showCanceledClassID\n%s", err)
+	}
+
+	_, err = db.AddCanceled(id)
+	if err != nil {
+		t.Fatalf("Failed AddCanceled func\n%s", err)
+	}
+}
+
 func TestGetYear(t *testing.T) {
 	testData := "2016/02/06"
 	out, err := getYear(testData)

--- a/go/model/model_test.go
+++ b/go/model/model_test.go
@@ -14,7 +14,6 @@ func TestConnectDB(t *testing.T) {
 	if err != nil {
 		t.Fatal("データベースに接続できません")
 	}
-
 }
 
 func TestInsert(t *testing.T) {
@@ -112,5 +111,33 @@ func TestDelete(t *testing.T) {
 	if err != nil || int(affectedRows) <= 0 {
 		t.Fatalf("deleteに失敗\n%s", err)
 	}
+}
 
+func TestGetYear(t *testing.T) {
+	testData := "2016/02/06"
+	out, err := getYear(testData)
+	if err != nil {
+		t.Fatalf("Error getYear func: %s", err)
+	}
+	if out != 2016 {
+		t.Fatal("Failed GetYear func\n want: %s, got: %s", 2016, out)
+	}
+}
+
+func TestGetSeason(t *testing.T) {
+	out, err := getSeason("2016/01/01")
+	if err != nil {
+		t.Fatalf("Error getSeason func: %s", err)
+	}
+	if out != "autumn" {
+		t.Fatal("Failed GetSeason func\n want: %s, got: %s", "autumn", out)
+	}
+
+	out, err = getSeason("2016/05/01")
+	if err != nil {
+		t.Fatalf("Error getSeason func: %s", err)
+	}
+	if out != "spring" {
+		t.Fatal("Failed GetSeason func\n want: %s, got: %s", "spring", out)
+	}
 }

--- a/go/model/model_test.go
+++ b/go/model/model_test.go
@@ -8,6 +8,7 @@ type TestData struct {
 	SelectAll           KyukoData
 	Delete              KyukoData
 	ShowID              CanceledClass
+	IsExistToday        KyukoData
 	Add                 CanceledClass
 	Reason              Reason
 	Day                 Day
@@ -23,6 +24,7 @@ func init() {
 	testData.InsertCanceledClass = CanceledClass{Canceled: 10, Place: 1, Weekday: 1, Period: 1, Year: 2016, ClassName: "CanceledClass", Season: "spring", Instructor: "hoge man"}
 	testData.SelectAll = KyukoData{Place: 1, Weekday: 1, Period: 1, Day: "2016/09/26", ClassName: "SelectAll Test", Instructor: "tsetMan", Reason: "darui"}
 	testData.ShowID = CanceledClass{Canceled: 10, Place: 1, Weekday: 1, Period: 1, Year: 2016, ClassName: "ShowIDTest", Season: "spring", Instructor: "hoge man"}
+	testData.IsExistToday = KyukoData{Place: 1, Weekday: 1, Period: 1, Day: "2016/11/11", ClassName: "IsExistToday Test", Instructor: "tsetMan", Reason: "darui"}
 	testData.Delete = KyukoData{Place: 1, Weekday: 1, Period: 1, Day: "2016/09/26", ClassName: "Delete Test", Instructor: "tsetMan", Reason: "darui"}
 	testData.Add = CanceledClass{Canceled: 10, Place: 1, Weekday: 1, Period: 1, Year: 2016, ClassName: "ADDTest", Season: "spring", Instructor: "hoge man"}
 	testData.Reason = Reason{CanceledClassID: 1, Reason: "darui"}
@@ -33,6 +35,7 @@ func deleteTestData() {
 	db.DeleteWhereDayAndClassName("2016/09/26", "Insert Test")
 	db.DeleteWhereDayAndClassName("2016/09/26", "SelectAll Test")
 	db.DeleteWhereDayAndClassName("2016/09/26", "Delete Test")
+	db.DeleteWhereDayAndClassName("2016/11/11", "IsExistToday Test")
 
 	id, _ := db.ShowCanceledClassID(testData.InsertCanceledClass)
 	db.deleteCanceled(id)
@@ -124,8 +127,27 @@ func TestShowCanceledClassID(t *testing.T) {
 
 	_, err = db.deleteCanceled(id)
 	if err != nil {
-		t.Fatalf("Error ShowCanceledClass: failed DeleteCnacled func\n%s", err)
+		t.Fatalf("Error ShowCanceledClassID: failed DeleteCnacled func\n%s", err)
 	}
+}
+
+func TestIsExistToday(t *testing.T) {
+	defer deleteTestData()
+	var err error
+
+	if isExist, err := db.IsExistToday(testData.IsExistToday); isExist || err != nil {
+		t.Fatalf("Faleid IsExistToday\n%s", err)
+	}
+
+	_, err = db.Insert(testData.IsExistToday)
+	if err != nil {
+		t.Fatalf("Error IsExistToday: failed Insert func\n%s", err)
+	}
+
+	if isExist, err := db.IsExistToday(testData.IsExistToday); !isExist || err != nil {
+		t.Fatalf("Faleid IsExistToday\n%s", err)
+	}
+
 }
 
 func TestDelete(t *testing.T) {

--- a/go/twitter/twitter.go
+++ b/go/twitter/twitter.go
@@ -76,7 +76,7 @@ func CreateContent(kyuko []model.KyukoData) ([]string, error) {
 	tweetLen := 9
 	for _, line := range lines {
 		lineLen := utf8.RuneCountInString(line)
-		if tweetLen + lineLen > 140 {
+		if tweetLen+lineLen > 140 {
 			tws = append(tws, tw)
 			tw = ""
 			tw = KANJIweekday + "曜日の休講情報\n"


### PR DESCRIPTION
KyukoRankのAPIのため
実行時に
kyukoData(昔)
CanceledClass(新)
どちらもで保存するようにする

Task
- [x] 同じ日に同じデータが来た時にDBにInsertしない